### PR TITLE
[MATCH] 매칭 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -37,6 +38,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/signalmatch_backend/match/config/KafkaTopicsConfig.java
+++ b/src/main/java/com/signalmatch_backend/match/config/KafkaTopicsConfig.java
@@ -1,0 +1,16 @@
+package com.signalmatch_backend.match.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KafkaTopicsConfig {
+    public static final String MATCH_EVENTS="match.events";
+
+    @Bean
+    public NewTopic matchRequestsTopic() {
+        // partitions=3, replicationFactor=1
+        return new NewTopic(MATCH_EVENTS, 3, (short) 1);
+    }
+}

--- a/src/main/java/com/signalmatch_backend/match/consumer/MatchRequestedConsumer.java
+++ b/src/main/java/com/signalmatch_backend/match/consumer/MatchRequestedConsumer.java
@@ -1,0 +1,32 @@
+package com.signalmatch_backend.match.consumer;
+
+import com.signalmatch_backend.match.domain.enums.MatchStatus;
+import com.signalmatch_backend.match.dto.MatchRequestedEvent;
+import com.signalmatch_backend.match.repository.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchRequestedConsumer {
+
+    private final MatchRepository matchRepository;
+
+    @KafkaListener(topics = "match.events", groupId = "match-service")
+    public void onMessage(MatchRequestedEvent event) {
+        log.info("[match.events] received: {}", event);
+
+        matchRepository.findById(event.matchId()).ifPresent(match -> {
+            // 데모 로직
+            String status = event.status();
+            match.setStatus(MatchStatus.valueOf(status));
+            matchRepository.save(match);
+            log.info("Match {} -> {}", match.getMatchId(), match.getStatus());
+        });
+    }
+}

--- a/src/main/java/com/signalmatch_backend/match/controller/MatchController.java
+++ b/src/main/java/com/signalmatch_backend/match/controller/MatchController.java
@@ -1,0 +1,32 @@
+package com.signalmatch_backend.match.controller;
+
+
+import com.signalmatch_backend.common.domain.ApiResponse;
+import com.signalmatch_backend.match.dto.MatchCreateRequest;
+import com.signalmatch_backend.match.dto.MatchRequestedEvent;
+import com.signalmatch_backend.match.service.MatchService;
+import com.signalmatch_backend.user.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/matches")
+@Tag(name = "Matching", description = "매칭 관련 API입니다.")
+public class MatchController {
+
+    public final MatchService matchService;
+
+    @PostMapping
+    @Operation(summary = "매칭 요청하기", description = "투자자와 스타트업 간의 매칭을 생성하는 API 입니다.")
+    public ResponseEntity<ApiResponse<Long>> createMatch(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody MatchCreateRequest matchCreateRequest) {
+        Long matchId = matchService.createMatch(matchCreateRequest.investorId(), matchCreateRequest.startupId());
+        return ResponseEntity.ok(ApiResponse.success("매칭이 생성되었습니다.", matchId));
+    }
+}

--- a/src/main/java/com/signalmatch_backend/match/domain/Match.java
+++ b/src/main/java/com/signalmatch_backend/match/domain/Match.java
@@ -29,6 +29,10 @@ public class Match extends BaseEntity {
     @Column(nullable = false, length = 20)
     private MatchStatus status;
 
-    @Column(nullable = false)
+    @Column()
     private LocalDateTime matchedAt;
+
+    public void setStatus(MatchStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/signalmatch_backend/match/domain/enums/MatchStatus.java
+++ b/src/main/java/com/signalmatch_backend/match/domain/enums/MatchStatus.java
@@ -1,3 +1,3 @@
 package com.signalmatch_backend.match.domain.enums;
 
-public enum MatchStatus { PROPOSED, ACCEPTED, REJECTED, CANCELLED }
+public enum MatchStatus { REQUESTED, PROPOSED, ACCEPTED, REJECTED, CANCELLED }

--- a/src/main/java/com/signalmatch_backend/match/dto/MatchCreateRequest.java
+++ b/src/main/java/com/signalmatch_backend/match/dto/MatchCreateRequest.java
@@ -1,0 +1,7 @@
+package com.signalmatch_backend.match.dto;
+
+public record MatchCreateRequest(
+        Long investorId,
+        Long startupId
+) {
+}

--- a/src/main/java/com/signalmatch_backend/match/dto/MatchRequestedEvent.java
+++ b/src/main/java/com/signalmatch_backend/match/dto/MatchRequestedEvent.java
@@ -1,0 +1,12 @@
+package com.signalmatch_backend.match.dto;
+
+import java.time.LocalDateTime;
+
+public record MatchRequestedEvent(
+        Long matchId,
+        Long startupId,
+        Long investorId,
+        String status,              // "REQUESTED" 등
+        LocalDateTime requestedAt
+) {
+}

--- a/src/main/java/com/signalmatch_backend/match/repository/MatchRepository.java
+++ b/src/main/java/com/signalmatch_backend/match/repository/MatchRepository.java
@@ -1,0 +1,8 @@
+package com.signalmatch_backend.match.repository;
+
+import com.signalmatch_backend.match.domain.Match;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRepository extends JpaRepository<Match, Long> {
+
+}

--- a/src/main/java/com/signalmatch_backend/match/service/MatchEventPublisher.java
+++ b/src/main/java/com/signalmatch_backend/match/service/MatchEventPublisher.java
@@ -1,0 +1,40 @@
+package com.signalmatch_backend.match.service;
+
+import com.signalmatch_backend.match.config.KafkaTopicsConfig;
+import com.signalmatch_backend.match.dto.MatchRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchEventPublisher {
+
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${app.kafka.enabled}")
+    private boolean kafkaEnabled;
+
+    public void publishMatchRequested(MatchRequestedEvent event) {
+        if (!kafkaEnabled) {
+            log.info("[NO-KAFKA] skip publish: {}", event);
+            return;
+        }
+        String key = String.valueOf(event.investorId()); // 파티셔닝 키
+        kafkaTemplate.send(KafkaTopicsConfig.MATCH_EVENTS, key, event)
+                .whenComplete((res, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka send failed", ex);
+                    } else {
+                        log.info("Kafka sent topic={}, partition={}, offset={}",
+                                res.getRecordMetadata().topic(),
+                                res.getRecordMetadata().partition(),
+                                res.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/src/main/java/com/signalmatch_backend/match/service/MatchService.java
+++ b/src/main/java/com/signalmatch_backend/match/service/MatchService.java
@@ -1,0 +1,37 @@
+package com.signalmatch_backend.match.service;
+
+import com.signalmatch_backend.match.domain.Match;
+import com.signalmatch_backend.match.domain.enums.MatchStatus;
+import com.signalmatch_backend.match.dto.MatchRequestedEvent;
+import com.signalmatch_backend.match.repository.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+    private final MatchRepository matchRepository;
+    private final MatchEventPublisher publisher;
+
+    public Long createMatch(Long startupId, Long investorId) {
+        Match match = Match.builder()
+                .startupId(startupId)
+                .investorId(investorId)
+                .status(MatchStatus.REQUESTED)
+                .build();
+        match = matchRepository.save(match);
+
+        // 2) 이벤트 발행
+        publisher.publishMatchRequested(new MatchRequestedEvent(
+                match.getMatchId(),
+                match.getStartupId(),
+                match.getInvestorId(),
+                match.getStatus().name(),
+                LocalDateTime.now()
+        ));
+        return match.getMatchId();
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #18 

## 📝작업 내용

> 스타트업과 투자자 간의 매칭을 생성하는 API를 구현했습니다.

- docker에서 단일 kafka를 사용해서 이벤트 처리 하도록 관련 코드 작성했습니다.

1. KafkaTopicsConfig: 스프링이 Kafka 브로커에 토픽을 자동 생성해주는 설정 클래스 입니다. (파티션 개수는 3개고, 단일 브로커 환경이라 1로 설정해뒀습니다.
2. MatchRequestedConsumer: 메시지 소비자로, Kafka에서 온 이벤트를 받아 DB의 Match 상태를 업데이트 하는 Consumer 입니다.
3. MatchEventPublisher : 메시지 생산자로 , MatchRequestedEvent를 match.events 토픽으로 발행하는 Producer 입니다.

- controller를 통해 매칭 생성이 들어오면, service에서 db에 저장 후 REQUESTED 이벤트가 발생하도록 구현했습니다.

### 스크린샷
<img width="534" height="196" alt="스크린샷 2025-10-13 17 11 30" src="https://github.com/user-attachments/assets/240378a6-48e4-4ab6-b546-ab003213a06d" />
<img width="662" height="144" alt="스크린샷 2025-10-13 17 11 46" src="https://github.com/user-attachments/assets/98cb5a30-a503-4aae-9d1f-2a597f2195c4" />

## 💬리뷰 요구사항(선택)

> MatchRequestedConsumer는 추천 알고리즘 개발 후 수정하겠습니다.

