### PR TITLE
[MATCH] 매칭 거부 및 해제

### DIFF
--- a/src/main/java/com/signalmatch_backend/match/consumer/MatchEventConsumer.java
+++ b/src/main/java/com/signalmatch_backend/match/consumer/MatchEventConsumer.java
@@ -39,4 +39,24 @@ public class MatchEventConsumer {
             log.info("Match {} -> {}", match.getMatchId(), match.getStatus());
         });
     }
+
+    @KafkaHandler
+    public void onRejected(MatchRequestedEvent event){
+        log.info("[match.events] rejected: {}", event);
+        matchRepository.findById(event.matchId()).ifPresent(match -> {
+            match.setStatus(MatchStatus.valueOf(event.status())); // ACCEPTED
+            matchRepository.save(match);
+            log.info("Match {} -> {}", match.getMatchId(), match.getStatus());
+        });
+    }
+
+    @KafkaHandler
+    public void onCanceled(MatchRequestedEvent event){
+        log.info("[match.events] rejected: {}", event);
+        matchRepository.findById(event.matchId()).ifPresent(match -> {
+            match.setStatus(MatchStatus.valueOf(event.status())); // ACCEPTED
+            matchRepository.save(match);
+            log.info("Match {} -> {}", match.getMatchId(), match.getStatus());
+        });
+    }
 }

--- a/src/main/java/com/signalmatch_backend/match/controller/MatchController.java
+++ b/src/main/java/com/signalmatch_backend/match/controller/MatchController.java
@@ -2,8 +2,10 @@ package com.signalmatch_backend.match.controller;
 
 
 import com.signalmatch_backend.common.domain.ApiResponse;
+import com.signalmatch_backend.match.dto.CancelRequest;
 import com.signalmatch_backend.match.dto.MatchCreateRequest;
 import com.signalmatch_backend.match.dto.MatchRequestedEvent;
+import com.signalmatch_backend.match.dto.RejectRequest;
 import com.signalmatch_backend.match.service.MatchService;
 import com.signalmatch_backend.user.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,5 +43,39 @@ public class MatchController {
         matchService.acceptMatch(userId, matchId);
         return ResponseEntity.ok(ApiResponse.success("매칭이 수락되었습니다."));
 
+    }
+
+    @PostMapping("/{matchId}/reject")
+    @Operation(summary = "매칭 거부하기", description = "요청된 매칭을 거부하는 API 입니다.")
+    public ResponseEntity<ApiResponse<Void>> rejectMatch(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long matchId,
+            @RequestBody(required = false) RejectRequest body
+    ){
+        Long userId = customUserDetails.getUser().getUserId();
+        matchService.rejectMatch(
+                userId,
+                matchId,
+                body == null ? null : body.reasonCode(),
+                body == null ? null : body.reasonText()
+        );
+        return ResponseEntity.ok(ApiResponse.success("매칭이 거부되었습니다."));
+    }
+
+    @PostMapping("/{matchId}/cancel")
+    @Operation(summary = "매칭 해제하기", description = "매칭을 해제하는 API 입니다.")
+    public ResponseEntity<ApiResponse<Void>> cancelMatch(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long matchId,
+            @RequestBody(required = false)CancelRequest body
+            ){
+        Long userId = customUserDetails.getUser().getUserId();
+        matchService.cancelMatch(
+                userId,
+                matchId,
+                body == null ? null : body.reasonCode(),
+                body == null ? null : body.reasonText()
+        );
+        return ResponseEntity.ok(ApiResponse.success("매칭이 해제되었습니다."));
     }
 }

--- a/src/main/java/com/signalmatch_backend/match/domain/Match.java
+++ b/src/main/java/com/signalmatch_backend/match/domain/Match.java
@@ -3,6 +3,7 @@ package com.signalmatch_backend.match.domain;
 
 import com.signalmatch_backend.common.domain.BaseEntity;
 import com.signalmatch_backend.match.domain.enums.MatchStatus;
+import com.signalmatch_backend.user.domain.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,11 +33,19 @@ public class Match extends BaseEntity {
     @Column
     private LocalDateTime matchedAt;
 
+    // 거절/취소/종료 시각
+    @Column
+    private LocalDateTime endedAt;
+
+    //누가 요청했는지(STARTUP or INVESTOR)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole requestedBy;
+
     public void setStatus(MatchStatus status) {
         this.status = status;
     }
 
-    public void setMatchedAt(LocalDateTime matchedAt) {
-        this.matchedAt = matchedAt;
-    }
+    public void setMatchedAt(LocalDateTime matchedAt) { this.matchedAt = matchedAt; }
+    public void setEndedAt(LocalDateTime endedAt) { this.endedAt = endedAt; }
 }

--- a/src/main/java/com/signalmatch_backend/match/domain/enums/MatchReasonCode.java
+++ b/src/main/java/com/signalmatch_backend/match/domain/enums/MatchReasonCode.java
@@ -1,0 +1,12 @@
+package com.signalmatch_backend.match.domain.enums;
+
+public enum MatchReasonCode {
+    NOT_INTERESTED,           // 관심 없음
+    OUT_OF_SCOPE,             // 산업/단계/지역 불일치
+    TIMING,                   // 타이밍 이슈(라운드/내부 상황)
+    DUPLICATE,                // 중복/이미 접촉 중
+    TERMS_UNACCEPTABLE,       // 조건 불만족
+    SPAM_OR_ABUSE,            // 스팸/부적절
+    MISTAKE,                  // 실수로 요청
+    OTHER
+}

--- a/src/main/java/com/signalmatch_backend/match/dto/CancelRequest.java
+++ b/src/main/java/com/signalmatch_backend/match/dto/CancelRequest.java
@@ -1,0 +1,5 @@
+package com.signalmatch_backend.match.dto;
+
+import com.signalmatch_backend.match.domain.enums.MatchReasonCode;
+
+public record CancelRequest(MatchReasonCode reasonCode, String reasonText) {}

--- a/src/main/java/com/signalmatch_backend/match/dto/MatchCanceledEvent.java
+++ b/src/main/java/com/signalmatch_backend/match/dto/MatchCanceledEvent.java
@@ -1,0 +1,16 @@
+package com.signalmatch_backend.match.dto;
+
+import com.signalmatch_backend.match.domain.enums.MatchReasonCode;
+
+import java.time.LocalDateTime;
+
+public record MatchCanceledEvent(
+        Long matchId,
+        Long startupId,
+        Long investorId,
+        String status,
+        LocalDateTime canceledAt,
+        MatchReasonCode reasonCode,
+        String reasonText
+) {
+}

--- a/src/main/java/com/signalmatch_backend/match/dto/MatchRejectedEvent.java
+++ b/src/main/java/com/signalmatch_backend/match/dto/MatchRejectedEvent.java
@@ -1,0 +1,15 @@
+package com.signalmatch_backend.match.dto;
+
+import com.signalmatch_backend.match.domain.enums.MatchReasonCode;
+
+import java.time.LocalDateTime;
+
+public record MatchRejectedEvent(
+        Long matchId,
+        Long startupId,
+        Long investorId,
+        String status,
+        LocalDateTime rejectedAt,
+        MatchReasonCode reasonCode,
+        String reasonText
+) {}

--- a/src/main/java/com/signalmatch_backend/match/dto/RejectRequest.java
+++ b/src/main/java/com/signalmatch_backend/match/dto/RejectRequest.java
@@ -1,0 +1,5 @@
+package com.signalmatch_backend.match.dto;
+
+import com.signalmatch_backend.match.domain.enums.MatchReasonCode;
+
+public record RejectRequest(MatchReasonCode reasonCode, String reasonText) {}

--- a/src/main/java/com/signalmatch_backend/match/service/MatchEventPublisher.java
+++ b/src/main/java/com/signalmatch_backend/match/service/MatchEventPublisher.java
@@ -2,6 +2,8 @@ package com.signalmatch_backend.match.service;
 
 import com.signalmatch_backend.match.config.KafkaTopicsConfig;
 import com.signalmatch_backend.match.dto.MatchAcceptedEvent;
+import com.signalmatch_backend.match.dto.MatchCanceledEvent;
+import com.signalmatch_backend.match.dto.MatchRejectedEvent;
 import com.signalmatch_backend.match.dto.MatchRequestedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,11 +23,19 @@ public class MatchEventPublisher {
     private boolean kafkaEnabled;
 
     public void publishMatchRequested(MatchRequestedEvent event) {
-        publish(KafkaTopicsConfig.MATCH_EVENTS, event.investorId(), event);
+        publish(KafkaTopicsConfig.MATCH_EVENTS, event.matchId(), event);
     }
 
     public void publishMatchAccepted(MatchAcceptedEvent event) {
-        publish(KafkaTopicsConfig.MATCH_EVENTS, event.investorId(), event);
+        publish(KafkaTopicsConfig.MATCH_EVENTS, event.matchId(), event);
+    }
+
+    public void publishMatchRejected(MatchRejectedEvent event) {
+        publish(KafkaTopicsConfig.MATCH_EVENTS, event.matchId(),event);
+    }
+
+    public void publishMatchCanceled(MatchCanceledEvent event) {
+        publish(KafkaTopicsConfig.MATCH_EVENTS, event.matchId(),event);
     }
 
     // 공통 로직 분리

--- a/src/main/java/com/signalmatch_backend/match/service/MatchService.java
+++ b/src/main/java/com/signalmatch_backend/match/service/MatchService.java
@@ -6,8 +6,11 @@ import com.signalmatch_backend.investor.InvestorFinder;
 import com.signalmatch_backend.investor.domain.Investor;
 import com.signalmatch_backend.match.MatchFinder;
 import com.signalmatch_backend.match.domain.Match;
+import com.signalmatch_backend.match.domain.enums.MatchReasonCode;
 import com.signalmatch_backend.match.domain.enums.MatchStatus;
 import com.signalmatch_backend.match.dto.MatchAcceptedEvent;
+import com.signalmatch_backend.match.dto.MatchCanceledEvent;
+import com.signalmatch_backend.match.dto.MatchRejectedEvent;
 import com.signalmatch_backend.match.dto.MatchRequestedEvent;
 import com.signalmatch_backend.match.repository.MatchRepository;
 import com.signalmatch_backend.startup.StartupFinder;
@@ -32,6 +35,7 @@ public class MatchService {
     private final UserFinder userFinder;
     private final MatchFinder matchFinder;
 
+    //매칭 생성
     public Long createMatch(long userId, long investorId, long startupId){
         Startup startup = startupFinder.findByStartupId(startupId);
         Investor investor = investorFinder.findByInvestorId(investorId);
@@ -46,6 +50,7 @@ public class MatchService {
                 .startupId(startup.getStartupId())
                 .investorId(investor.getInvestorId())
                 .status(MatchStatus.REQUESTED)
+                .requestedBy(user.getUserRole())
                 .build();
         match = matchRepository.save(match);
 
@@ -61,6 +66,7 @@ public class MatchService {
     }
 
 
+    //매칭 수락
     @Transactional
     public void acceptMatch(Long userId, Long matchId) {
         User user = userFinder.findByUserId(userId);
@@ -85,6 +91,62 @@ public class MatchService {
                 match.getInvestorId(),
                 match.getStatus().name(),
                 LocalDateTime.now()
+        ));
+    }
+
+    //매칭 거부
+    public void rejectMatch(Long userId, Long matchId,
+                            MatchReasonCode code, String text) {
+        User actor = userFinder.findByUserId(userId);
+        Match match = matchFinder.findByMatchId(matchId);
+
+        Startup startup = startupFinder.findByStartupId(match.getStartupId());
+        Investor investor = investorFinder.findByInvestorId(match.getInvestorId());
+
+        assertRejectAuthority(actor, startup, investor, match);
+
+        assertTransition(match.getStatus(), MatchStatus.REJECTED);
+
+        match.setEndedAt(LocalDateTime.now());
+        match.setStatus(MatchStatus.REJECTED);
+        match = matchRepository.save(match);
+
+        publisher.publishMatchRejected(new MatchRejectedEvent(
+                match.getMatchId(),
+                match.getStartupId(),
+                match.getInvestorId(),
+                match.getStatus().name(),
+                LocalDateTime.now(),
+                code,
+                text
+        ));
+    }
+
+    //매칭 해제
+    public void cancelMatch(Long userId, Long matchId,
+                            MatchReasonCode code, String text) {
+        User user = userFinder.findByUserId(userId);
+        Match match = matchFinder.findByMatchId(matchId);
+
+        Startup startup = startupFinder.findByStartupId(match.getStartupId());
+        Investor investor = investorFinder.findByInvestorId(match.getInvestorId());
+
+        assertOwnership(user, startup, investor);
+
+        assertTransition(match.getStatus(), MatchStatus.CANCELLED);
+
+        match.setStatus(MatchStatus.CANCELLED);
+        match.setEndedAt(LocalDateTime.now());
+        match = matchRepository.save(match);
+
+        publisher.publishMatchCanceled(new MatchCanceledEvent(
+                match.getMatchId(),
+                match.getStartupId(),
+                match.getInvestorId(),
+                match.getStatus().name(),
+                LocalDateTime.now(),
+                code,
+                text
         ));
     }
 
@@ -122,12 +184,32 @@ public class MatchService {
     private void assertTransition(MatchStatus current, MatchStatus target) {
         if (current == target) return;
         boolean allowed = switch (current) {
-            case REQUESTED, PROPOSED -> (target == MatchStatus.ACCEPTED);
+            case REQUESTED, PROPOSED -> (target == MatchStatus.ACCEPTED
+                    || target == MatchStatus.REJECTED
+                    || target == MatchStatus.CANCELLED);
+            case ACCEPTED -> (target == MatchStatus.CANCELLED);
             default -> false;
         };
-        if (!allowed) {
+        if (!allowed) throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+
+    //매칭 거부 가능 여부
+    private void assertRejectAuthority(User actor, Startup s, Investor i, Match m) {
+        if (m.getRequestedBy() == UserRole.STARTUP) {
+            // 스타트업이 요청 → 투자자 측만 거절 가능
+            if (!i.getOwner().getUserId().equals(actor.getUserId())) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+        } else if (m.getRequestedBy() == UserRole.INVESTOR) {
+            // 투자자가 요청 → 스타트업 측만 거절 가능
+            if (!s.getOwner().getUserId().equals(actor.getUserId())) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+        } else {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #24 

## 📝작업 내용

> 매칭 거부 및 해제를 하는 API를 구현했습니다.

- 운영 로그 및 분석을 위해 매칭 거부, 해제 시 이유 코드(reasonCode)와 텍스트(reasonText)를 받도록 DTO 구성했습니다. -> 두 필드는 옵션입니다.
- 거부 로직은 요청을 받은 사용자만 수행할 수 있도록 제한했습니다. 이로 인해 Match 도메인에 requestBy(요청자 정보) 필드를 추가하고, 거부 가능 여부를 검증하는 로직을 추가했습니다.
- 매칭 거부 및 해제 시 종료 시간 기록이 필요하다고 판단하여 Match 도메인에 endedAt 필드 추가했습니다.
- 각 요청 시 status가 DB에서 변경되며, 상태 전이에 따라 kafka event(MatchRejectedEvent, MatchCancelledEvent)가 발행됩니다.

### 스크린샷
<img width="1420" height="717" alt="스크린샷 2025-10-16 10 50 56" src="https://github.com/user-attachments/assets/ecf240df-6625-434a-8f24-59dd821865f6" />
<img width="1424" height="601" alt="스크린샷 2025-10-16 11 12 11" src="https://github.com/user-attachments/assets/8059ce98-a657-42b1-a793-c37b782a52f0" />
<img width="1420" height="537" alt="스크린샷 2025-10-16 11 12 20" src="https://github.com/user-attachments/assets/a4ad4632-eece-48b9-9101-1d17cb7c9f59" />
<img width="920" height="93" alt="스크린샷 2025-10-16 11 11 52" src="https://github.com/user-attachments/assets/87ede1d4-26cc-4fb2-b29a-4e95bc27e17e" />


## 💬리뷰 요구사항(선택)

> 이유 코드는 DB에 저장되지 않으며, kafka 이벤트 payload로만 전달되어 운영 로그 및 통계 분석에 활용됩니다.
