### PR TITLE
[DOCUMENT] 문서 s3 presign url 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     //kafka
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    //s3
+    implementation "software.amazon.awssdk:s3:2.25.40"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/signalmatch_backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/signalmatch_backend/common/exception/ErrorCode.java
@@ -34,7 +34,17 @@ public enum ErrorCode {
 
 	//Matching Error
 	MATCH_ALREADY_USED(HttpStatus.BAD_REQUEST,"이미 진행 중인 매칭입니다."),
-	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭의 정보를 찾을 수 없습니다.");
+	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭의 정보를 찾을 수 없습니다."),
+
+	//File Error
+	INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 파일 형식입니다."),
+	INVALID_MIME_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 MIME 타입입니다."),
+	IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 파일 크기가 허용 범위를 초과했습니다."),
+	IR_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "IR 파일 크기가 허용 범위를 초과했습니다."),
+	PDF_ONLY(HttpStatus.BAD_REQUEST, "IR 파일은 PDF만 가능합니다."),
+	FILE_EXTENSION_REQUIRED(HttpStatus.BAD_REQUEST, "파일 확장자가 필요합니다.");
+
+
     private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/signalmatch_backend/document/domain/Document.java
+++ b/src/main/java/com/signalmatch_backend/document/domain/Document.java
@@ -19,5 +19,5 @@ public class Document extends BaseEntity {
     private Long userId;
 
     @Column(nullable = false, length = 2048)
-    private String documentUrl;
+    private String objectKey;
 }

--- a/src/main/java/com/signalmatch_backend/document/repository/DocumentRepository.java
+++ b/src/main/java/com/signalmatch_backend/document/repository/DocumentRepository.java
@@ -1,0 +1,10 @@
+package com.signalmatch_backend.document.repository;
+
+import com.signalmatch_backend.document.domain.Document;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+    List<Document> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/signalmatch_backend/s3/S3Config.java
+++ b/src/main/java/com/signalmatch_backend/s3/S3Config.java
@@ -1,0 +1,58 @@
+package com.signalmatch_backend.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.region.static:}")
+    private String region;
+
+    @Value("${aws.s3.credentials.accessKey:}")
+    private String accessKey;
+
+    @Value("${aws.s3.credentials.secretKey:}")
+    private String secretKey;
+
+
+    private AwsCredentialsProvider provider() {
+        if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        }
+        // 로컬 프로파일/EC2 IAM Role 등 기본 체인 사용
+        return DefaultCredentialsProvider.create();}
+
+    private Region resolveRegion() {
+        if (StringUtils.hasText(region)) {
+            return Region.of(region);}
+        // 환경변수/프로파일/인스턴스 메타데이터 등에서 지역 자동 해석
+        return DefaultAwsRegionProviderChain.builder().build().getRegion();
+ }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(resolveRegion())
+                .credentialsProvider(provider())
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(resolveRegion())
+                .credentialsProvider(provider())
+                .build();
+    }
+}

--- a/src/main/java/com/signalmatch_backend/s3/S3Controller.java
+++ b/src/main/java/com/signalmatch_backend/s3/S3Controller.java
@@ -1,0 +1,47 @@
+package com.signalmatch_backend.s3;
+
+import com.signalmatch_backend.common.domain.ApiResponse;
+import com.signalmatch_backend.common.exception.CustomException;
+import com.signalmatch_backend.common.exception.ErrorCode;
+import com.signalmatch_backend.s3.dto.PresignRequest;
+import com.signalmatch_backend.s3.dto.PresignResponse;
+import com.signalmatch_backend.s3.dto.UploadType;
+import com.signalmatch_backend.user.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/s3")
+@Tag(name = "S3", description = "S3 Presign URL 관련 API입니다.")
+@PreAuthorize("isAuthenticated()")
+public class S3Controller {
+
+    private final S3Service s3UploadService;
+
+    @PostMapping("/profile-image/presign")
+    @Operation(summary = "프로필 업로드 url 생성",description = "프로필 사진을 s3에 업로드 하는 Presign url을 발급합니다.")
+    public ResponseEntity<ApiResponse<PresignResponse>> presignProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                       @RequestBody PresignRequest req) {
+        PresignResponse response = s3UploadService.presignFor(UploadType.PROFILE_IMAGE, customUserDetails.getUser().getUserId(), req);
+        return ResponseEntity.ok(ApiResponse.success("프로필 업로드 url이 발급되었습니다",response));
+    }
+
+    @PostMapping("/ir/presign")
+    @Operation(summary = "스타트업 IR 업로드 url 생성",description = "IR을 s3에 업로드 하는 Presign url을 발급합니다.")
+    public ResponseEntity<ApiResponse<PresignResponse>> presignIr(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                  @RequestBody PresignRequest req,
+                                                                  @RequestParam Long startupId) {
+        PresignResponse response = s3UploadService.presignFor(UploadType.IR_FILE, startupId, req);
+        return ResponseEntity.ok(ApiResponse.success("IR 업로드 url이 발급되었습니다",response));
+
+    }
+
+
+}

--- a/src/main/java/com/signalmatch_backend/s3/S3KeyResolver.java
+++ b/src/main/java/com/signalmatch_backend/s3/S3KeyResolver.java
@@ -1,0 +1,21 @@
+package com.signalmatch_backend.s3;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Component
+public class S3KeyResolver {
+
+    public String profileImageKey(Long userId, String ext) {
+        return String.format("users/%d/profile/%s.%s", userId, UUID.randomUUID(), ext);
+    }
+
+    public String irFileKey(Long companyId, String ext) {
+        LocalDate now = LocalDate.now();
+        return String.format("companies/%d/ir/%04d/%02d/%02d/%s.%s",
+                companyId, now.getYear(), now.getMonthValue(), now.getDayOfMonth(),
+                UUID.randomUUID(), ext);
+    }
+}

--- a/src/main/java/com/signalmatch_backend/s3/S3Service.java
+++ b/src/main/java/com/signalmatch_backend/s3/S3Service.java
@@ -1,0 +1,105 @@
+package com.signalmatch_backend.s3;
+
+import ch.qos.logback.classic.Logger;
+import com.signalmatch_backend.common.exception.CustomException;
+import com.signalmatch_backend.common.exception.ErrorCode;
+import com.signalmatch_backend.s3.dto.PresignRequest;
+import com.signalmatch_backend.s3.dto.PresignResponse;
+import com.signalmatch_backend.s3.dto.UploadType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Presigner presigner;
+    private final S3Client s3Client;
+    private final S3KeyResolver keyResolver;
+
+    @Value("${aws.s3.credentials.bucket}")
+    private String bucket;
+
+    private static final Set<String> IMG_EXT = Set.of("jpg","jpeg","png");
+    private static final Set<String> IR_EXT  = Set.of("pdf");
+    private static final long MAX_IMG_BYTES = 5L * 1024 * 1024; //5MB
+    private static final long MAX_IR_BYTES  = 50L * 1024 * 1024; //50MB
+
+    public PresignResponse presignFor(UploadType type, Long ownerId, PresignRequest req) {
+        // 1) 검증
+        String ext = extractExt(req.fileName());
+        String mime = Optional.ofNullable(req.mimeType()).orElse("");
+        long len = Optional.ofNullable(req.contentLength()).orElse(0L);
+
+        switch (type) {
+            case PROFILE_IMAGE -> {
+                if (!IMG_EXT.contains(ext)) {
+                    throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+                }
+                if (!mime.startsWith("image/")) {
+                    throw new CustomException(ErrorCode.INVALID_MIME_TYPE);
+                }
+                if (len <= 0 || len > MAX_IMG_BYTES) {
+                    throw new CustomException(ErrorCode.IMAGE_SIZE_EXCEEDED);
+                }
+            }
+            case IR_FILE -> {
+                if (!IR_EXT.contains(ext)) {
+                    throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+                }
+                if (!"application/pdf".equals(mime)) {
+                    throw new CustomException(ErrorCode.PDF_ONLY);
+                }
+                if (len <= 0 || len > MAX_IR_BYTES) {
+                    throw new CustomException(ErrorCode.IR_SIZE_EXCEEDED);
+                }
+            }
+        }
+
+        // 2) 키 생성
+        String key = switch (type) {
+            case PROFILE_IMAGE -> keyResolver.profileImageKey(ownerId, ext);
+            case IR_FILE -> keyResolver.irFileKey(ownerId, ext);
+        };
+
+        // 3) PutObjectRequest
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(mime)
+                .build();
+
+        // 4) presign
+        PutObjectPresignRequest presign = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5)) //유효기간 5분
+                .putObjectRequest(objectRequest)
+                .build();
+
+        PresignedPutObjectRequest pre = presigner.presignPutObject(presign);
+
+        // 5) 응답 (클라이언트가 그대로 헤더를 넣어 PUT하도록)
+        Map<String,String> headers = new HashMap<>();
+        pre.signedHeaders().forEach((k,v) -> headers.put(k, String.join(",", v)));
+
+        return new PresignResponse(pre.url().toString(), "PUT", headers, key);
+    }
+
+    private String extractExt(String fileName) {
+        int i = fileName.lastIndexOf('.');
+        if (i < 0) throw new CustomException(ErrorCode.FILE_EXTENSION_REQUIRED);
+        return fileName.substring(i + 1).toLowerCase();
+    }
+}

--- a/src/main/java/com/signalmatch_backend/s3/dto/PresignRequest.java
+++ b/src/main/java/com/signalmatch_backend/s3/dto/PresignRequest.java
@@ -1,0 +1,27 @@
+package com.signalmatch_backend.s3.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "S3 Presigned URL 요청 DTO")
+public record PresignRequest(
+        @Schema(
+                description = "업로드할 파일의 원본 이름 (확장자 포함)",
+                example = "signalmatch.png"
+        )
+        String fileName,
+
+
+        @Schema(
+                description = "파일의 MIME 타입 (브라우저가 감지한 Content-Type)",
+                example = "image/png or application/pdf"
+        )
+        String mimeType,
+
+        @Schema(
+                description = "파일 크기 (바이트 단위)",
+                example = "34567"
+        )
+        Long contentLength
+) {
+
+}

--- a/src/main/java/com/signalmatch_backend/s3/dto/PresignResponse.java
+++ b/src/main/java/com/signalmatch_backend/s3/dto/PresignResponse.java
@@ -1,0 +1,36 @@
+package com.signalmatch_backend.s3.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+
+@Schema(description = "S3 Presigned URL 응답 DTO")
+public record PresignResponse(
+
+        @Schema(
+                description = "S3로 직접 업로드할 presigned URL",
+                example = "https://your-bucket.s3.ap-northeast-2.amazonaws.com/users/1/profile/uuid.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&..."
+        )
+        String url,
+
+        @Schema(
+                description = "요청 메서드 (PUT 또는 POST)",
+                example = "PUT"
+        )
+        String method,
+
+        @Schema(
+                description = "S3 업로드 시 함께 포함해야 하는 헤더들",
+                example = "{\"host\": \"your-bucket.s3.ap-northeast-2.amazonaws.com\"}"
+        )
+        Map<String, String> headers,
+
+
+        @Schema(
+                description = "S3 object key (업로드 완료 후 서버에 저장할 경로)",
+                example = "users/1/profile/uuid.png"
+        )
+        String key
+) {
+}

--- a/src/main/java/com/signalmatch_backend/s3/dto/UploadType.java
+++ b/src/main/java/com/signalmatch_backend/s3/dto/UploadType.java
@@ -1,0 +1,6 @@
+package com.signalmatch_backend.s3.dto;
+
+public enum UploadType {
+    PROFILE_IMAGE,
+    IR_FILE
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #39 

## 📝작업 내용

> 프로필, IR 자료를 s3에 업로드하는 presign url을 발급받는 API을 구현했습니다.

- 각 분기된 url에 POST을 호출하여 presign url을 발급 받으면 됩니다.
- response에 있는 url로 해당 이미지나 파일을 PUT 메서드를 사용해 업로드할 수 있습니다.

### 스크린샷
<img width="1135" height="526" alt="스크린샷 2025-11-05 10 56 10" src="https://github.com/user-attachments/assets/e5f74977-9e89-4668-94dc-f2991e1829de" />
<img width="1048" height="485" alt="스크린샷 2025-11-05 10 56 01" src="https://github.com/user-attachments/assets/8d93fdc5-ce16-410b-8d3d-b54a3f782401" />

## 💬리뷰 요구사항(선택)

> Document 의 도메인에서, documenturl 필드를 삭제 후 ObjectKey 필드로 변경했습니다.  변경 이유는 URL은 고유하지 않다고 생각했고 S3 Key는 S3 내부의 객체 식별자로 고유하고 안정적이라고 생각했습니다. 따라서 DB에는 Key만 저장하고 실제 파일 접근 시점에서는 Key를 기반으로 Presigned URL 또는 CloudFront Signed URL을 동적으로 생성하도록 설계할 예정입니다.

> 또한, application.yml에 s3 설정 부분을 추가한 코드가 있으니 노션 확인 후 반영 부탁드립니다.