### PR TITLE
[bookmark] 즐겨찾기 추가

### DIFF
--- a/src/main/java/com/signalmatch_backend/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/controller/BookmarkController.java
@@ -1,0 +1,34 @@
+package com.signalmatch_backend.bookmark.controller;
+
+import com.signalmatch_backend.bookmark.dto.BookmarkRequest;
+import com.signalmatch_backend.bookmark.dto.BookmarkResponse;
+import com.signalmatch_backend.bookmark.service.BookmarkService;
+import com.signalmatch_backend.common.domain.ApiResponse;
+import com.signalmatch_backend.user.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.shaded.com.google.protobuf.Api;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "Bookmark",description = "즐겨찾기 관련 API입니다.")
+public class BookmarkController {
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/bookmarks")
+    @Operation(summary = "즐겨찾기 추가" ,description = "로그인한 사용자의 관심있는 투자자 또는 스타트업을 즐겨찾기에 추가합니다.")
+    public ResponseEntity<ApiResponse<BookmarkResponse>> bookmarkAdd(@AuthenticationPrincipal CustomUserDetails customUserDetails,@RequestBody BookmarkRequest request){
+        Long userId = customUserDetails.getUser().getUserId();
+        BookmarkResponse response = bookmarkService.addBookmark(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 추가되었습니다.",response));
+    }
+
+}

--- a/src/main/java/com/signalmatch_backend/bookmark/dto/BookmarkRequest.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/dto/BookmarkRequest.java
@@ -1,0 +1,12 @@
+package com.signalmatch_backend.bookmark.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BookmarkRequest(
+    Long investorId,
+
+    Long startupId
+
+) {
+
+}

--- a/src/main/java/com/signalmatch_backend/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/dto/BookmarkResponse.java
@@ -1,0 +1,11 @@
+package com.signalmatch_backend.bookmark.dto;
+
+public record BookmarkResponse(
+    Long bookmarkId,
+    Long investorId,
+
+    Long startupId
+
+) {
+
+}

--- a/src/main/java/com/signalmatch_backend/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.signalmatch_backend.bookmark.repository;
+
+import com.signalmatch_backend.bookmark.domain.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
+    boolean existsByUserIdAndInvestorIdAndStartupId(Long userId, Long investorId, Long startupId);
+
+}

--- a/src/main/java/com/signalmatch_backend/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/service/BookmarkService.java
@@ -1,0 +1,40 @@
+package com.signalmatch_backend.bookmark.service;
+
+import com.signalmatch_backend.bookmark.domain.Bookmark;
+import com.signalmatch_backend.bookmark.dto.BookmarkRequest;
+import com.signalmatch_backend.bookmark.dto.BookmarkResponse;
+import com.signalmatch_backend.bookmark.repository.BookmarkRepository;
+import com.signalmatch_backend.common.exception.CustomException;
+import com.signalmatch_backend.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    @Transactional
+    public BookmarkResponse addBookmark(Long userId, BookmarkRequest request){
+        Long investorId = request.investorId();
+        Long startupId = request.startupId();
+
+        if((investorId == null && startupId == null)|| (investorId != null && startupId != null)){
+            throw new CustomException(ErrorCode.BOOKMARK_ONLY_ONE_TARGET_ALLOWED);
+        }
+
+        if (bookmarkRepository.existsByUserIdAndInvestorIdAndStartupId(userId, investorId, startupId)){
+            throw new CustomException(ErrorCode.BOOKMARK_ALREADY_EXISTS);
+        }
+        Bookmark bookmark= Bookmark.builder()
+            .userId(userId)
+            .investorId(investorId)
+            .startupId(startupId)
+            .build();
+        Bookmark savedBookmark = bookmarkRepository.save(bookmark);
+
+        return new BookmarkResponse(savedBookmark.getBookmarkId(),savedBookmark.getInvestorId(),savedBookmark.getStartupId());
+    }
+
+}

--- a/src/main/java/com/signalmatch_backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/signalmatch_backend/common/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
 	NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리소스를 찾을 수 없습니다."),
 	MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
 
+	//Bookmark Error
+	BOOKMARK_ONLY_ONE_TARGET_ALLOWED(HttpStatus.BAD_REQUEST,"investorId 또는 startupId 중 하나만 값이 있어야 합니다."),
+	BOOKMARK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 북마크가 존재합니다."),
 	//Auth
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
@@ -35,8 +38,12 @@ public enum ErrorCode {
 	//Matching Error
 	MATCH_ALREADY_USED(HttpStatus.BAD_REQUEST,"이미 진행 중인 매칭입니다."),
 	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭의 정보를 찾을 수 없습니다.");
+
+
     private final HttpStatus status;
 	private final String message;
+
+
 
 	ErrorCode(HttpStatus status, String message) {
 		this.status = status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #38 

## 📝작업 내용

> 로그인한 사용자가 관심있는 투자자 또는 스타트업을 즐겨찾기에 추가하는 API를 구현했습니다.

즐겨찾기 등록 시 investorId와 startupId 중 하나만 값이 존재해야 하며,
두 값이 모두 null이거나, 동시에 값이 존재하는 경우는 잘못된 요청으로 간주하여 예외를 발생시킵니다.

### 스크린샷
<img width="550" height="487" alt="북마크추가" src="https://github.com/user-attachments/assets/72c3d694-9980-4a62-9629-f0c62da9618a" />
<img width="507" height="364" alt="스크린샷 2025-11-05 121019" src="https://github.com/user-attachments/assets/bfd6e975-3210-44d2-ad48-d89913e613f0" />
<img width="833" height="220" alt="화면 캡처 2025-11-05 121113" src="https://github.com/user-attachments/assets/b6a7bc6f-c132-48a2-88fc-130337d24860" />


