### PR TITLE
[startup] 프로필 생성 API 수정

### DIFF
--- a/src/main/java/com/signalmatch_backend/investor/domain/Investor.java
+++ b/src/main/java/com/signalmatch_backend/investor/domain/Investor.java
@@ -36,7 +36,6 @@ public class Investor extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String contactEmail;
 
-    private String position; //직책
     private String phoneNumber;
     private String websiteUrl;
 
@@ -71,9 +70,6 @@ public class Investor extends BaseEntity {
         }
         if(request.contactEmail() != null){
             this.contactEmail= request.contactEmail();
-        }
-        if(request.position() != null ){
-            this.position = request.position();
         }
         if(request.phoneNumber() != null ){
             this.phoneNumber = request.phoneNumber();

--- a/src/main/java/com/signalmatch_backend/investor/dto/InvestorProfileCreateRequest.java
+++ b/src/main/java/com/signalmatch_backend/investor/dto/InvestorProfileCreateRequest.java
@@ -18,8 +18,7 @@ public record InvestorProfileCreateRequest(
 
     @Schema(description = "투자자 이메일")
     String contactEmail,
-    @Schema(description = "직함")
-    String position,
+
     @Schema(description = "연락처")
     String phoneNumber,
     @Schema(description = "url")

--- a/src/main/java/com/signalmatch_backend/investor/dto/InvestorProfileInfo.java
+++ b/src/main/java/com/signalmatch_backend/investor/dto/InvestorProfileInfo.java
@@ -19,8 +19,7 @@ public record InvestorProfileInfo(
     String investorName,
     @Schema(description = "투자자 이메일")
     String contactEmail,
-    @Schema(description = "직함")
-    String position,
+
     @Schema(description = "연락처")
     String phoneNumber,
     @Schema(description = "url")
@@ -49,7 +48,6 @@ public record InvestorProfileInfo(
             investor.getViews(),
             investor.getInvestorName(),
             investor.getContactEmail(),
-            investor.getPosition(),
             investor.getPhoneNumber(),
             investor.getWebsiteUrl(),
             investor.getIntro(),

--- a/src/main/java/com/signalmatch_backend/investor/dto/InvestorProfileUpdateRequest.java
+++ b/src/main/java/com/signalmatch_backend/investor/dto/InvestorProfileUpdateRequest.java
@@ -8,8 +8,6 @@ public record InvestorProfileUpdateRequest(
     String investorName,
     @Schema(description = "투자자 이메일")
     String contactEmail,
-    @Schema(description = "직함")
-    String position,
     @Schema(description = "연락처")
     String phoneNumber,
     @Schema(description = "url")

--- a/src/main/java/com/signalmatch_backend/investor/service/InvestorService.java
+++ b/src/main/java/com/signalmatch_backend/investor/service/InvestorService.java
@@ -47,7 +47,6 @@ public class InvestorService {
             .owner(owner)
             .investorName(request.investorName())
             .contactEmail(request.contactEmail())
-            .position(request.position())
             .phoneNumber(request.phoneNumber())
             .websiteUrl(request.websiteUrl())
             .intro(request.intro())
@@ -92,6 +91,7 @@ public class InvestorService {
         Investor investor = investorRepository.findByOwner(owner).orElseThrow(() -> new CustomException(ErrorCode.INVESTOR_NOT_FOUND));
         investor.update(request);
         if(request.preferredStages() != null){
+
             updatePreferredStages(investor,request.preferredStages());
         }
         if(request.preferredAreas() != null){

--- a/src/main/java/com/signalmatch_backend/startup/controller/StartupController.java
+++ b/src/main/java/com/signalmatch_backend/startup/controller/StartupController.java
@@ -2,6 +2,7 @@ package com.signalmatch_backend.startup.controller;
 
 import com.signalmatch_backend.common.domain.ApiResponse;
 import com.signalmatch_backend.startup.dto.StartupProfileCreateRequest;
+import com.signalmatch_backend.startup.dto.StartupProfileCreateResponse;
 import com.signalmatch_backend.startup.dto.StartupProfileInfo;
 import com.signalmatch_backend.startup.dto.StartupProfileUpdateRequest;
 import com.signalmatch_backend.startup.service.StartupService;
@@ -28,10 +29,10 @@ public class StartupController {
     private final StartupService startupService;
     @PostMapping("/startups/me")
     @Operation(summary = "스타트업 프로필 생성",description = "사용자의 스타트업 프로필을 생성합니다.")
-    public ResponseEntity<ApiResponse<Void>> startupProfileCreate(@AuthenticationPrincipal CustomUserDetails customUserDetails, @Valid @RequestBody StartupProfileCreateRequest request){
+    public ResponseEntity<ApiResponse<StartupProfileCreateResponse>> startupProfileCreate(@AuthenticationPrincipal CustomUserDetails customUserDetails, @Valid @RequestBody StartupProfileCreateRequest request){
         Long userId = customUserDetails.getUser().getUserId();
-        startupService.createStartupProfile(userId, request);
-        return ResponseEntity.ok(ApiResponse.success("스타트업 프로필 생성이 완료되었습니다."));
+        StartupProfileCreateResponse response = startupService.createStartupProfile(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("스타트업 프로필 생성이 완료되었습니다.",response));
     }
 
     @PatchMapping("/startups/me")

--- a/src/main/java/com/signalmatch_backend/startup/domain/StartupProfile.java
+++ b/src/main/java/com/signalmatch_backend/startup/domain/StartupProfile.java
@@ -45,11 +45,13 @@ public class StartupProfile {
 
     @Enumerated(EnumType.STRING) @Column(length = 10)
     private ScaleType scale;
+
+    @Column(length = 255) private String history; //대표 약력
     // StartupProfile.java
 
     public void update(StartupProfileUpdateRequest request) {
         if (request.foundingDate() != null) {
-            this.foundingDate = request.foundingDate();
+            this.foundingDate = LocalDate.parse(request.foundingDate());
         }
         if (request.address() != null) {
             this.address = request.address();
@@ -77,6 +79,9 @@ public class StartupProfile {
         }
         if (request.scale() != null ) {
             this.scale = ScaleType.valueOf(request.scale().toUpperCase());
+        }
+        if (request.history() != null) {
+            this.history = request.history();
         }
     }
 }

--- a/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileCreateRequest.java
+++ b/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileCreateRequest.java
@@ -17,7 +17,7 @@ public record StartupProfileCreateRequest(
     String status,
     @NotNull
     @Schema(description = "설립일")
-    LocalDate foundingDate,
+    String foundingDate,
     @NotBlank
     @Schema(description = "주소")
     String address,
@@ -63,6 +63,9 @@ public record StartupProfileCreateRequest(
     String investorStages,
     @NotEmpty
     @Schema(description = "산업분야")
-    List<String> businessAreas
+    List<String> businessAreas,
+    @NotBlank
+    @Schema(description = "대표 약력")
+    String history
 ) {
 }

--- a/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileCreateResponse.java
+++ b/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileCreateResponse.java
@@ -1,0 +1,10 @@
+package com.signalmatch_backend.startup.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StartupProfileCreateResponse(
+    @Schema(description = "스타트업 ID")
+    Long StartupId
+
+) {
+}

--- a/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileInfo.java
+++ b/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileInfo.java
@@ -14,7 +14,7 @@ public record StartupProfileInfo(
     String status,
 
     @Schema(description = "설립일")
-    LocalDate foundingDate,
+    String foundingDate,
 
     @Schema(description = "주소")
     String address,
@@ -60,13 +60,15 @@ public record StartupProfileInfo(
     String investorStages,
 
     @Schema(description = "산업분야")
-    List<String> businessAreas
+    List<String> businessAreas,
+    @Schema(description = "대표 약력")
+    String history
 ) {
     public static StartupProfileInfo toStartupProfileInfo(Startup startup, List<String> startupBusinessAreas){
         return new StartupProfileInfo(
             startup.getStartupName(),
             startup.getStatus().name(),
-            startup.getStartupProfile().getFoundingDate(),
+            startup.getStartupProfile().getFoundingDate().toString(),
             startup.getStartupProfile().getAddress(),
             startup.getStartupProfile().getHomepageUrl(),
             startup.getStartupProfile().getContactEmail(),
@@ -81,7 +83,8 @@ public record StartupProfileInfo(
             startup.getStartupFinance().getFundingRounds(),
             startup.getStartupFinance().getTotalFunding(),
             startup.getStartupFinance().getInvestorStages().name(),
-            startupBusinessAreas
+            startupBusinessAreas,
+            startup.getStartupProfile().getHistory()
         );
     }
 }

--- a/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileUpdateRequest.java
+++ b/src/main/java/com/signalmatch_backend/startup/dto/StartupProfileUpdateRequest.java
@@ -17,7 +17,7 @@ public record StartupProfileUpdateRequest(
     String status,
 
     @Schema(description = "설립일")
-    LocalDate foundingDate,
+    String foundingDate,
 
     @Schema(description = "주소")
     String address,
@@ -63,7 +63,10 @@ public record StartupProfileUpdateRequest(
     String investorStages,
 
     @Schema(description = "산업분야")
-    List<String> businessAreas
+    List<String> businessAreas,
+
+    @Schema(description = "대표 약력")
+    String history
 ) {
 
 }

--- a/src/main/java/com/signalmatch_backend/startup/service/StartupService.java
+++ b/src/main/java/com/signalmatch_backend/startup/service/StartupService.java
@@ -15,12 +15,15 @@ import com.signalmatch_backend.startup.domain.enums.ScaleType;
 import com.signalmatch_backend.startup.domain.enums.StartupStatus;
 import com.signalmatch_backend.startup.domain.key.StartupBusinessAreaKey;
 import com.signalmatch_backend.startup.dto.StartupProfileCreateRequest;
+import com.signalmatch_backend.startup.dto.StartupProfileCreateResponse;
 import com.signalmatch_backend.startup.dto.StartupProfileInfo;
 import com.signalmatch_backend.startup.dto.StartupProfileUpdateRequest;
 import com.signalmatch_backend.startup.repository.StartupBusinessAreaRepository;
 import com.signalmatch_backend.startup.repository.StartupRepository;
 import com.signalmatch_backend.user.UserFinder;
 import com.signalmatch_backend.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.sql.ast.tree.expression.Star;
@@ -36,7 +39,7 @@ public class StartupService {
     private final StartupBusinessAreaRepository startupBusinessAreaRepository;
     private final StartupFinder startupFinder;
     @Transactional
-    public void createStartupProfile(Long userId, StartupProfileCreateRequest request){
+    public StartupProfileCreateResponse createStartupProfile(Long userId, StartupProfileCreateRequest request){
         User owner = userFinder.findByUserId(userId);
         if(startupRepository.existsByOwner(owner)){
             throw new CustomException(ErrorCode.PROFILE_ALREADY_EXISTS);
@@ -50,7 +53,7 @@ public class StartupService {
 
         StartupProfile newStartupProfile = StartupProfile.builder()
             .startup(newStartup)
-            .foundingDate(request.foundingDate())
+            .foundingDate(LocalDate.parse(request.foundingDate()))
             .address(request.address())
             .homepageUrl(request.homepageUrl())
             .contactEmail(request.contactEmail())
@@ -60,6 +63,7 @@ public class StartupService {
             .employeeCount(request.employeeCount())
             .legalType(LegalType.valueOf(request.legalType().toUpperCase()))
             .scale(ScaleType.valueOf(request.scale().toUpperCase()))
+            .history(request.history())
             .build();
 
         newStartup.addStartupProfile(newStartupProfile);
@@ -88,7 +92,7 @@ public class StartupService {
                 .build())
             .toList();
         startupBusinessAreaRepository.saveAll(businessAreaList);
-
+       return new StartupProfileCreateResponse(savedStartup.getStartupId());
 
     }
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #54 

## 📝작업 내용

> 
스타트업 프로필 생성 response에 startupId 추가

스타트업 프로필 생성에 대표 약력(history) 필드 추가

스타트업 프로필 생성DTO 설립일(foundingDate) 필드 타입을 String으로 수정

투자자 프로필 생성에 position 삭제

### 스크린샷

<img width="605" height="633" alt="스크린샷 2025-11-19 231809" src="https://github.com/user-attachments/assets/8067010b-6acb-4839-8de7-dd6bcf45d9c1" />
<img width="454" height="386" alt="스크린샷 2025-11-19 231516" src="https://github.com/user-attachments/assets/30e32d45-5c04-4e43-a9d1-23b399326dc6" />
<img width="566" height="347" alt="스크린샷 2025-11-19 232050" src="https://github.com/user-attachments/assets/fd7f864d-e50b-44b0-949b-8c13f92b88c9" />

