### PR TITLE
[search] 통합 검색 API 구현

### DIFF
--- a/src/main/java/com/signalmatch_backend/investor/repository/InvestorPreferredAreaRepository.java
+++ b/src/main/java/com/signalmatch_backend/investor/repository/InvestorPreferredAreaRepository.java
@@ -5,9 +5,16 @@ import com.signalmatch_backend.investor.domain.InvestorPreferredArea;
 import com.signalmatch_backend.investor.domain.key.InvestorPreferredAreaKey;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InvestorPreferredAreaRepository extends JpaRepository<InvestorPreferredArea, InvestorPreferredAreaKey> {
     void deleteAllByInvestor_InvestorId(Long investorId);
 
     List<InvestorPreferredArea> findByInvestor(Investor investor);
+    @Query("SELECT ipa " +
+        "FROM InvestorPreferredArea ipa " +
+        "JOIN FETCH ipa.businessArea " +
+        "WHERE ipa.investor.investorId IN :investorIds")
+    List<InvestorPreferredArea> findAllByInvestorIds(@Param("investorIds") List<Long> investorIds);;
 }

--- a/src/main/java/com/signalmatch_backend/investor/repository/InvestorRepository.java
+++ b/src/main/java/com/signalmatch_backend/investor/repository/InvestorRepository.java
@@ -5,8 +5,9 @@ import com.signalmatch_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface InvestorRepository extends JpaRepository<Investor,Long> {
+public interface InvestorRepository extends JpaRepository<Investor,Long> ,JpaSpecificationExecutor<Investor> {
     boolean existsByOwner(User owner);
     Optional<Investor> findByOwner(User owner);
 }

--- a/src/main/java/com/signalmatch_backend/investor/repository/InvestorSpecification.java
+++ b/src/main/java/com/signalmatch_backend/investor/repository/InvestorSpecification.java
@@ -1,0 +1,52 @@
+package com.signalmatch_backend.investor.repository;
+
+import com.signalmatch_backend.investor.domain.Investor;
+import com.signalmatch_backend.investor.domain.InvestorPreferredArea;
+import com.signalmatch_backend.search.dto.InvestorSearch;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.List;
+import org.springframework.data.jpa.domain.Specification;
+public class InvestorSpecification {
+
+    public static Specification<Investor> search(String keyword, List<String> businessAreaNames) {
+        return (root, query, cb) -> {
+
+            query.distinct(true);
+            var predicate = cb.conjunction();
+
+            if (keyword != null && !keyword.isEmpty()) {
+                String like = "%" + keyword + "%";
+                predicate = cb.and(
+                    predicate,
+                    cb.or(
+                        cb.like(root.get("investorName"), like),
+                        cb.like(root.get("intro"), like),
+                        cb.like(root.get("organizationName"), like)
+                    )
+                );
+            }
+
+            if (businessAreaNames != null && !businessAreaNames.isEmpty()) {
+
+                Subquery<Long> subquery = query.subquery(Long.class);
+
+                Root<InvestorPreferredArea> subRoot = subquery.from(InvestorPreferredArea.class);
+
+                subquery.select(subRoot.get("investor").get("investorId"))
+                    .where(
+                        subRoot.get("businessArea").get("name").in(businessAreaNames)
+                    );
+
+                predicate = cb.and(
+                    predicate,
+                    root.get("investorId").in(subquery)
+                );
+            }
+
+            return predicate;
+        };
+    }
+}

--- a/src/main/java/com/signalmatch_backend/search/controller/SearchController.java
+++ b/src/main/java/com/signalmatch_backend/search/controller/SearchController.java
@@ -1,0 +1,37 @@
+package com.signalmatch_backend.search.controller;
+
+import com.signalmatch_backend.common.domain.ApiResponse;
+import com.signalmatch_backend.search.dto.SearchResponse;
+import com.signalmatch_backend.search.service.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/search")
+@Tag(name = "Search",description = "통합검색 API 입니다.")
+public class SearchController {
+    private final SearchService searchService;
+
+    @GetMapping
+    @Operation(summary = "통합 검색",description ="키워드와 산업분야로 스타트업과 투자자를 검색합니다.")
+    public ResponseEntity<ApiResponse<SearchResponse>> search(
+        String keyword,
+        @RequestParam(required = false) List<String> areas,
+        @ParameterObject @PageableDefault(page = 0, size = 10) Pageable pageable
+    ){
+        SearchResponse response = searchService.search(keyword,areas,pageable);
+        return ResponseEntity.ok(ApiResponse.success("통합 검색이 완료되었습니다.",response));
+    }
+
+}

--- a/src/main/java/com/signalmatch_backend/search/dto/InvestorSearch.java
+++ b/src/main/java/com/signalmatch_backend/search/dto/InvestorSearch.java
@@ -1,0 +1,29 @@
+package com.signalmatch_backend.search.dto;
+
+import com.signalmatch_backend.investor.domain.Investor;
+import com.signalmatch_backend.investor.domain.InvestorPreferredArea;
+import java.util.List;
+
+public record InvestorSearch(
+    String investorName,
+    String intro,
+    String organizationName,
+    String investorType,
+    List<String> preferredAreas
+) {
+    public static InvestorSearch from(Investor investor, List<InvestorPreferredArea> preferredAreas) {
+
+        List<String> areaNames = preferredAreas.stream()
+            .filter(a -> a.getInvestor().getInvestorId().equals(investor.getInvestorId()))
+            .map(a -> a.getBusinessArea().getName())
+            .toList();
+
+        return new InvestorSearch(
+            investor.getInvestorName(),
+            investor.getIntro(),
+            investor.getOrganizationName(),
+            investor.getInvestorType().name(),
+            areaNames
+        );
+    }
+}

--- a/src/main/java/com/signalmatch_backend/search/dto/SearchResponse.java
+++ b/src/main/java/com/signalmatch_backend/search/dto/SearchResponse.java
@@ -1,0 +1,16 @@
+package com.signalmatch_backend.search.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record SearchResponse(
+    List<StartupSearch> startups,
+    long totalStartupCount,
+    int totalStartupPages,
+    List<InvestorSearch> investors,
+    long totalInvestorCount,
+    int totalInvestorPages
+
+) {
+
+}

--- a/src/main/java/com/signalmatch_backend/search/dto/StartupSearch.java
+++ b/src/main/java/com/signalmatch_backend/search/dto/StartupSearch.java
@@ -1,0 +1,31 @@
+package com.signalmatch_backend.search.dto;
+
+import com.signalmatch_backend.startup.domain.Startup;
+import com.signalmatch_backend.startup.domain.StartupBusinessArea;
+import java.util.List;
+
+public record StartupSearch(
+    String startupName,
+    String intro,
+    String legalType,
+    String scale,
+    String investorStages,
+    List<String> businessAreas
+) {
+    public static StartupSearch from(Startup startup, List<StartupBusinessArea> areas) {
+
+        List<String> areaNames = areas.stream()
+            .filter(a -> a.getStartup().getStartupId().equals(startup.getStartupId()))
+            .map(a -> a.getBusinessArea().getName())
+            .toList();
+
+        return new StartupSearch(
+            startup.getStartupName(),
+            startup.getStartupProfile().getIntro(),
+            startup.getStartupProfile().getLegalType().name(),
+            startup.getStartupProfile().getScale().name(),
+            startup.getStartupFinance().getInvestorStages().name(),
+            areaNames
+        );
+    }
+}

--- a/src/main/java/com/signalmatch_backend/search/service/SearchService.java
+++ b/src/main/java/com/signalmatch_backend/search/service/SearchService.java
@@ -1,0 +1,101 @@
+package com.signalmatch_backend.search.service;
+
+import com.signalmatch_backend.investor.domain.Investor;
+import com.signalmatch_backend.investor.domain.InvestorPreferredArea;
+import com.signalmatch_backend.investor.repository.InvestorPreferredAreaRepository;
+import com.signalmatch_backend.investor.repository.InvestorRepository;
+import com.signalmatch_backend.investor.repository.InvestorSpecification;
+import com.signalmatch_backend.search.dto.InvestorSearch;
+import com.signalmatch_backend.search.dto.SearchResponse;
+import com.signalmatch_backend.search.dto.StartupSearch;
+import com.signalmatch_backend.startup.domain.Startup;
+import com.signalmatch_backend.startup.domain.StartupBusinessArea;
+import com.signalmatch_backend.startup.repository.StartupBusinessAreaRepository;
+import com.signalmatch_backend.startup.repository.StartupRepository;
+import com.signalmatch_backend.startup.repository.StartupSpecification;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final StartupRepository startupRepository;
+    private final InvestorRepository investorRepository;
+    private final InvestorPreferredAreaRepository investorPreferredAreaRepository;
+    private final StartupBusinessAreaRepository startupBusinessAreaRepository;
+
+    public SearchResponse search(String keyword, List<String> areas, Pageable pageable) {
+        //스타트업
+        Page<Startup> startupPage = startupRepository.findAll(
+            StartupSpecification.search(keyword, areas),
+            pageable
+        );
+
+        List<Startup> startups = startupPage.getContent();
+
+        List<Long> startupIds = startups.stream()
+            .map(Startup::getStartupId)
+            .toList();
+
+        List<StartupBusinessArea> allStartupAreas =
+            startupBusinessAreaRepository.findAllByStartupIds(startupIds);
+
+        Map<Long, List<StartupBusinessArea>> startupAreaMap = allStartupAreas.stream()
+            .collect(Collectors.groupingBy(sba -> sba.getStartup().getStartupId()));
+
+        List<StartupSearch> startupSearchList = startups.stream()
+            .map(startup -> StartupSearch.from(
+                startup,
+                startupAreaMap.getOrDefault(startup.getStartupId(), Collections.emptyList())
+            ))
+            .toList();
+
+        /////투자자
+        Page<Investor> investorPage = investorRepository.findAll(
+            InvestorSpecification.search(keyword, areas),
+            pageable
+        );
+
+        List<Investor> investors = investorPage.getContent();
+
+        List<InvestorSearch> investorSearchList;
+
+        List<Long> investorIds = investors.stream()
+            .map(Investor::getInvestorId)
+            .toList();
+
+
+        List<InvestorPreferredArea> allPreferredAreas =
+            investorPreferredAreaRepository.findAllByInvestorIds(investorIds);
+
+        Map<Long, List<InvestorPreferredArea>> investorAreaMap =
+            allPreferredAreas.stream()
+                .collect(Collectors.groupingBy(ipa -> ipa.getInvestor().getInvestorId()));
+
+
+        investorSearchList = investors.stream()
+                .map(investor -> InvestorSearch.from(
+                    investor,
+                    investorAreaMap.getOrDefault(investor.getInvestorId(), Collections.emptyList())
+                ))
+                .toList();
+
+        return new SearchResponse(
+                startupSearchList,
+                startupPage.getTotalElements(),
+                startupPage.getTotalPages(),
+                investorSearchList,
+                investorPage.getTotalElements(),
+                investorPage.getTotalPages()
+        );
+
+    }
+}

--- a/src/main/java/com/signalmatch_backend/startup/repository/StartupBusinessAreaRepository.java
+++ b/src/main/java/com/signalmatch_backend/startup/repository/StartupBusinessAreaRepository.java
@@ -1,14 +1,21 @@
 package com.signalmatch_backend.startup.repository;
 
+import com.signalmatch_backend.investor.domain.InvestorPreferredArea;
 import com.signalmatch_backend.startup.domain.Startup;
 import com.signalmatch_backend.startup.domain.StartupBusinessArea;
 import com.signalmatch_backend.startup.domain.key.StartupBusinessAreaKey;
 import java.util.List;
 import org.hibernate.sql.ast.tree.expression.Star;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StartupBusinessAreaRepository extends JpaRepository<StartupBusinessArea, StartupBusinessAreaKey> {
     void deleteAllByStartup_StartupId(Long startupId);
 
     List<StartupBusinessArea> findByStartup(Startup startup);
+
+    @Query("SELECT sba FROM StartupBusinessArea sba WHERE sba.startup.startupId IN :startupIds")
+    List<StartupBusinessArea> findAllByStartupIds(@Param("startupIds") List<Long> startupIds);
+
 }

--- a/src/main/java/com/signalmatch_backend/startup/repository/StartupRepository.java
+++ b/src/main/java/com/signalmatch_backend/startup/repository/StartupRepository.java
@@ -6,8 +6,9 @@ import com.signalmatch_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface StartupRepository extends JpaRepository<Startup, Long> {
+public interface StartupRepository extends JpaRepository<Startup, Long>, JpaSpecificationExecutor<Startup> {
     Optional<Startup> findByOwner(User user);
     boolean existsByOwner(User owner);
 }

--- a/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
+++ b/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
@@ -18,7 +18,8 @@ public class StartupSpecification {
                 String like = "%" + keyword + "%";
                 predicate = cb.and(predicate, cb.or(
                     cb.like(root.get("startupName"), like),
-                    cb.like(root.get("owner").get("name"), like)
+                    cb.like(root.get("owner").get("name"), like),
+                    cb.like(root.get("startupProfile").get("Intro"), like)
                 ));
             }
 

--- a/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
+++ b/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
@@ -18,7 +18,7 @@ public class StartupSpecification {
                 String like = "%" + keyword + "%";
                 predicate = cb.and(predicate, cb.or(
                     cb.like(root.get("startupName"), like),
-                    cb.like(root.get("owner").get("name"), like),
+                    cb.like(root.get("startupProfile").get("representativeName"), like),
                     cb.like(root.get("startupProfile").get("intro"), like)
                 ));
             }

--- a/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
+++ b/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
@@ -19,7 +19,7 @@ public class StartupSpecification {
                 predicate = cb.and(predicate, cb.or(
                     cb.like(root.get("startupName"), like),
                     cb.like(root.get("owner").get("name"), like),
-                    cb.like(root.get("startupProfile").get("Intro"), like)
+                    cb.like(root.get("startupProfile").get("intro"), like)
                 ));
             }
 

--- a/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
+++ b/src/main/java/com/signalmatch_backend/startup/repository/StartupSpecification.java
@@ -1,0 +1,37 @@
+package com.signalmatch_backend.startup.repository;
+
+import com.signalmatch_backend.startup.domain.Startup;
+import com.signalmatch_backend.startup.domain.StartupBusinessArea;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.List;
+import org.springframework.data.jpa.domain.Specification;
+public class StartupSpecification {
+    public static Specification<Startup> search(String keyword, List<String> areas) {
+        return (root, query, cb) -> {
+            query.distinct(true);
+            var predicate = cb.conjunction();
+
+            if (keyword != null && !keyword.isEmpty()) {
+                String like = "%" + keyword + "%";
+                predicate = cb.and(predicate, cb.or(
+                    cb.like(root.get("startupName"), like),
+                    cb.like(root.get("owner").get("name"), like)
+                ));
+            }
+
+            if (areas != null && !areas.isEmpty()) {
+                Subquery<Long> subquery = query.subquery(Long.class);
+                Root<StartupBusinessArea> subRoot = subquery.from(StartupBusinessArea.class);
+
+                subquery.select(subRoot.get("startup").get("startupId"))
+                    .where(subRoot.get("businessArea").get("name").in(areas));
+                predicate = cb.and(predicate, root.get("startupId").in(subquery));
+            }
+
+            return predicate;
+        };
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #37 

## 📝작업 내용

> 스타트업과 투자자를 대상으로
키워드 + 산업 분야 기준 검색 기능 구현

스타트업:
- 스타트업명, 대표자명, 소개글을 대상으로 키워드 검색 지원
- 지정된 산업 분야를 보유한 스타트업만 필터링

투자자:
- 투자자명, 소개글, 조직명을 대상으로 키워드 검색 지원
- 지정된 산업 분야(선호 투자 분야)를 보유한 투자자만 필터링

### 스크린샷

<img width="649" height="709" alt="스크린샷 2025-11-20 233137" src="https://github.com/user-attachments/assets/8053eae7-08e8-4af2-a46c-7c0e9b84c5d6" />
<img width="510" height="582" alt="스크린샷 2025-11-20 233143" src="https://github.com/user-attachments/assets/42d6d692-dcbf-46e7-a960-6dfaaaa61e33" />
<img width="730" height="708" alt="스크린샷 2025-11-20 233058" src="https://github.com/user-attachments/assets/5f3b5447-3a45-4288-873d-d161829e035c" />
<img width="524" height="598" alt="스크린샷 2025-11-20 233109" src="https://github.com/user-attachments/assets/e09fa8c9-8b96-4c8d-a6d0-800a50c1b1d6" />
