### PR TITLE
[search] 인기 순위 조회 API 구현

### DIFF
--- a/src/main/java/com/signalmatch_backend/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/controller/BookmarkController.java
@@ -3,6 +3,7 @@ package com.signalmatch_backend.bookmark.controller;
 import com.signalmatch_backend.bookmark.dto.BookmarkListResponse;
 import com.signalmatch_backend.bookmark.dto.BookmarkRequest;
 import com.signalmatch_backend.bookmark.dto.BookmarkResponse;
+import com.signalmatch_backend.bookmark.dto.StartupBookmarkInfo;
 import com.signalmatch_backend.bookmark.service.BookmarkService;
 import com.signalmatch_backend.common.domain.ApiResponse;
 import com.signalmatch_backend.user.jwt.CustomUserDetails;
@@ -49,6 +50,13 @@ public class BookmarkController {
     public ResponseEntity<ApiResponse<List<BookmarkListResponse>>> bookmarkGet(@AuthenticationPrincipal CustomUserDetails customUserDetails){
         Long userId = customUserDetails.getUser().getUserId();
         List<BookmarkListResponse> response = bookmarkService.getBookmarkList(userId);
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 목록의 조회가 완료되었습니다.",response));
+    }
+
+    @GetMapping("/search/best")
+    @Operation(summary = "스타트업 검색 인기 순위 조회", description = "스타트업 검색 인기 순위 Top 10을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<StartupBookmarkInfo>>> getTop10Rankings() {
+        List<StartupBookmarkInfo> response = bookmarkService.getTop10Startups();
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 목록의 조회가 완료되었습니다.",response));
     }
 

--- a/src/main/java/com/signalmatch_backend/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/controller/BookmarkController.java
@@ -57,7 +57,7 @@ public class BookmarkController {
     @Operation(summary = "스타트업 검색 인기 순위 조회", description = "스타트업 검색 인기 순위 Top 10을 조회합니다.")
     public ResponseEntity<ApiResponse<List<StartupBookmarkInfo>>> getTop10Rankings() {
         List<StartupBookmarkInfo> response = bookmarkService.getTop10Startups();
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 목록의 조회가 완료되었습니다.",response));
+        return ResponseEntity.ok(ApiResponse.success("스타트업 검색 인기 순위 조회가 완료되었습니다.",response));
     }
 
 }

--- a/src/main/java/com/signalmatch_backend/bookmark/dto/StartupBookmarkInfo.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/dto/StartupBookmarkInfo.java
@@ -1,0 +1,15 @@
+package com.signalmatch_backend.bookmark.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StartupBookmarkInfo {
+    private Long startupId;
+    private String startupName;
+    private String intro;
+    private Long bookmarkCount;
+}

--- a/src/main/java/com/signalmatch_backend/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/repository/BookmarkRepository.java
@@ -1,9 +1,12 @@
 package com.signalmatch_backend.bookmark.repository;
 
 import com.signalmatch_backend.bookmark.domain.Bookmark;
+import com.signalmatch_backend.bookmark.dto.StartupBookmarkInfo;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
     boolean existsByUserIdAndInvestorIdAndStartupId(Long userId, Long investorId, Long startupId);
@@ -13,4 +16,13 @@ public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
     Optional<Bookmark> findByUserIdAndStartupId(Long userId, Long startupId);
 
     List<Bookmark> findByUserId(Long userId);
+
+    @Query("SELECT new com.signalmatch_backend.bookmark.dto.StartupBookmarkInfo(" +
+        "s.startupId, s.startupName, sp.intro, COUNT(b)) " +
+        "FROM Startup s " +
+        "LEFT JOIN s.startupProfile sp " +
+        "LEFT JOIN Bookmark b ON b.startupId = s.startupId " +
+        "GROUP BY s.startupId, s.startupName, sp.intro " +
+        "ORDER BY COUNT(b) DESC")
+    List<StartupBookmarkInfo> findTop10ByBookmarkCount(Pageable pageable);
 }

--- a/src/main/java/com/signalmatch_backend/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/service/BookmarkService.java
@@ -4,6 +4,7 @@ import com.signalmatch_backend.bookmark.domain.Bookmark;
 import com.signalmatch_backend.bookmark.dto.BookmarkListResponse;
 import com.signalmatch_backend.bookmark.dto.BookmarkRequest;
 import com.signalmatch_backend.bookmark.dto.BookmarkResponse;
+import com.signalmatch_backend.bookmark.dto.StartupBookmarkInfo;
 import com.signalmatch_backend.bookmark.repository.BookmarkRepository;
 import com.signalmatch_backend.common.exception.CustomException;
 import com.signalmatch_backend.common.exception.ErrorCode;
@@ -17,6 +18,8 @@ import com.signalmatch_backend.user.domain.enums.UserRole;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,6 +107,11 @@ public class BookmarkService {
         Bookmark bookmark = bookmarkRepository.findByUserIdAndStartupId(userId, startup.getStartupId())
             .orElseThrow(() -> new CustomException(ErrorCode.BOOKMARK_NOT_FOUND));
         bookmarkRepository.delete(bookmark);
+    }
+
+    public List<StartupBookmarkInfo> getTop10Startups() {
+        Pageable pageable = PageRequest.of(0, 10);
+        return bookmarkRepository.findTop10ByBookmarkCount(pageable);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>  Closes #61  

## 📝작업 내용
- 스타트업 북마크 수 기준 Top 10 랭킹 조회 기능 구현
- 스타트업id, 스타트업 이름, 소개, 북마크 수를 포함한 DTO 및 Repository 쿼리 추가
- 북마크 수 내림차순 정렬 및 Pageable을 활용한 상위 10개 데이터 반환
<img width="406" height="417" alt="image" src="https://github.com/user-attachments/assets/aece2931-f309-4791-8e7f-d87f0d2bf6b0" />

## 💬리뷰 요구사항(선택)

테스트 데이터 1건으로만 검증했습니다. 추가 데이터 삽입 후 다시 테스트 해야할 것 같습니다.
