### PR TITLE
[user] 마이페이지 DTO 수정

### DIFF
--- a/src/main/java/com/signalmatch_backend/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/signalmatch_backend/bookmark/repository/BookmarkRepository.java
@@ -25,4 +25,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
         "GROUP BY s.startupId, s.startupName, sp.intro " +
         "ORDER BY COUNT(b) DESC")
     List<StartupBookmarkInfo> findTop10ByBookmarkCount(Pageable pageable);
+
+    long countByInvestorId(Long investorId);
+    long countByStartupId(Long startupId);
 }

--- a/src/main/java/com/signalmatch_backend/investor/service/InvestorService.java
+++ b/src/main/java/com/signalmatch_backend/investor/service/InvestorService.java
@@ -2,6 +2,8 @@ package com.signalmatch_backend.investor.service;
 
 import com.signalmatch_backend.BusinessArea.domain.BusinessArea;
 import com.signalmatch_backend.BusinessArea.repository.BusinessAreaRepository;
+import com.signalmatch_backend.bookmark.repository.BookmarkRepository;
+import com.signalmatch_backend.bookmark.service.BookmarkService;
 import com.signalmatch_backend.common.exception.CustomException;
 import com.signalmatch_backend.common.exception.ErrorCode;
 import com.signalmatch_backend.investor.InvestorFinder;
@@ -36,6 +38,7 @@ public class InvestorService {
     private final InvestorPreferredAreaRepository investorPreferredAreaRepository;
     private final InvestorPreferredStageRepository investorPreferredStageRepository;
     private final InvestorFinder investorFinder;
+    private final BookmarkRepository bookmarkRepository;
     @Transactional
     public InvestorProfileCreateResponse createInvestorProfile(Long userId, InvestorProfileCreateRequest request){
         User owner = userFinder.findByUserId(userId);
@@ -142,5 +145,8 @@ public class InvestorService {
             .toList();
 
         return  InvestorProfileInfo.toInvestorProfileInfo(investor, investorPreferredAreaNames);
+    }
+    public long getMyBookmarkCount(Long investorId) {
+        return bookmarkRepository.countByInvestorId(investorId);
     }
 }

--- a/src/main/java/com/signalmatch_backend/startup/service/StartupService.java
+++ b/src/main/java/com/signalmatch_backend/startup/service/StartupService.java
@@ -2,8 +2,10 @@ package com.signalmatch_backend.startup.service;
 
 import com.signalmatch_backend.BusinessArea.domain.BusinessArea;
 import com.signalmatch_backend.BusinessArea.repository.BusinessAreaRepository;
+import com.signalmatch_backend.bookmark.repository.BookmarkRepository;
 import com.signalmatch_backend.common.exception.CustomException;
 import com.signalmatch_backend.common.exception.ErrorCode;
+import com.signalmatch_backend.investor.domain.Investor;
 import com.signalmatch_backend.startup.StartupFinder;
 import com.signalmatch_backend.startup.domain.Startup;
 import com.signalmatch_backend.startup.domain.StartupBusinessArea;
@@ -38,6 +40,7 @@ public class StartupService {
     private final BusinessAreaRepository businessAreaRepository;
     private final StartupBusinessAreaRepository startupBusinessAreaRepository;
     private final StartupFinder startupFinder;
+    private final BookmarkRepository bookmarkRepository;
     @Transactional
     public StartupProfileCreateResponse createStartupProfile(Long userId, StartupProfileCreateRequest request){
         User owner = userFinder.findByUserId(userId);
@@ -134,5 +137,8 @@ public class StartupService {
             .map(area -> area.getBusinessArea().getName()).toList();
 
         return  StartupProfileInfo.toStartupProfileInfo(startup,startupBusinessAreaNames);
+    }
+    public long getMyBookmarkCount(Long startupId) {
+        return bookmarkRepository.countByStartupId(startupId);
     }
 }

--- a/src/main/java/com/signalmatch_backend/user/dto/InvestorMyPageResponse.java
+++ b/src/main/java/com/signalmatch_backend/user/dto/InvestorMyPageResponse.java
@@ -4,11 +4,11 @@ import com.signalmatch_backend.investor.dto.InvestorProfileInfo;
 
 public record InvestorMyPageResponse(
         InvestorProfileInfo profile,
-        long matchedStartupCount,
+        long bookmarkCount,
         String profileImageUrl
 ) implements MyPageResponse{
-    public static InvestorMyPageResponse of(InvestorProfileInfo profile, long matchedCount,String profileImageUrl) {
-        return new InvestorMyPageResponse(profile, matchedCount, profileImageUrl);
+    public static InvestorMyPageResponse of(InvestorProfileInfo profile, long bookmarkCount,String profileImageUrl) {
+        return new InvestorMyPageResponse(profile, bookmarkCount, profileImageUrl);
     }
 
 }

--- a/src/main/java/com/signalmatch_backend/user/dto/StartupMyPageResponse.java
+++ b/src/main/java/com/signalmatch_backend/user/dto/StartupMyPageResponse.java
@@ -5,10 +5,10 @@ import com.signalmatch_backend.startup.dto.StartupProfileInfo;
 
 public record StartupMyPageResponse(
         StartupProfileInfo profile,
-        long matchedInvestorCount,
+        long bookmarkCount,
         String profileImageUrl
 ) implements MyPageResponse {
-    public static StartupMyPageResponse of(StartupProfileInfo profile, long matchedCount,String profileImageUrl) {
-        return new StartupMyPageResponse(profile, matchedCount, profileImageUrl);
+    public static StartupMyPageResponse of(StartupProfileInfo profile, long bookmarkCount,String profileImageUrl) {
+        return new StartupMyPageResponse(profile, bookmarkCount, profileImageUrl);
     }
 }

--- a/src/main/java/com/signalmatch_backend/user/service/UserService.java
+++ b/src/main/java/com/signalmatch_backend/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.signalmatch_backend.user.service;
 
+import com.signalmatch_backend.bookmark.domain.Bookmark;
+import com.signalmatch_backend.bookmark.service.BookmarkService;
 import com.signalmatch_backend.common.exception.CustomException;
 import com.signalmatch_backend.common.exception.ErrorCode;
 import com.signalmatch_backend.document.Service.DocumentService;
@@ -76,16 +78,16 @@ public class UserService {
 
         if(user.getUserRole().equals(UserRole.INVESTOR)){
             Investor investor = investorFinder.findByOwner(user);
-            long matchedStartupCount = matchRepository.countByInvestorIdAndStatus(investor.getInvestorId(), MatchStatus.ACCEPTED);
+            long bookmarkCount = investorService.getMyBookmarkCount(investor.getInvestorId());
             InvestorProfileInfo profile = investorService.findInvestorProfile(userId);
             String profileImageUrl = documentService.getLatestProfileImageUrl(userId);
-            return InvestorMyPageResponse.of(profile, matchedStartupCount, profileImageUrl);
+            return InvestorMyPageResponse.of(profile, bookmarkCount, profileImageUrl);
         }else{
             Startup startup = startupFinder.findByOwner(user);
-            long matchedInvestorCount = matchRepository.countByStartupIdAndStatus(startup.getStartupId(), MatchStatus.ACCEPTED);
+            long bookmarkCount = startupService.getMyBookmarkCount(startup.getStartupId());
             StartupProfileInfo profile = startupService.findStartupProfile(userId);
             String profileImageUrl = documentService.getLatestProfileImageUrl(userId);
-            return StartupMyPageResponse.of(profile, matchedInvestorCount, profileImageUrl   );
+            return StartupMyPageResponse.of(profile, bookmarkCount, profileImageUrl   );
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #65 

## 📝작업 내용

> 프론트요청으로 /api/me 마이페이지 조회 API 수정했습니다. 

마이페이지 dto의 matchedInvestorCount,matchedStartupCount 필드를 bookmarkCount로 바꿨습니다.

### 스크린샷
<img width="792" height="147" alt="스크린샷 2025-12-01 152116" src="https://github.com/user-attachments/assets/addeed5e-fdc1-412b-9373-493873ac6ed4" />
<img width="555" height="673" alt="스크린샷 2025-12-01 152019" src="https://github.com/user-attachments/assets/92edbc84-b976-46ad-8b39-3c88f10fcf5f" />
<img width="553" height="638" alt="스크린샷 2025-12-01 151851" src="https://github.com/user-attachments/assets/63cd9dae-e223-4da1-9815-c694dbcded48" />

